### PR TITLE
Allow for sorting of dynamic collections

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,6 +159,25 @@ function plugin(opts){
         settings.metadata;
     });
 
+    /* Check if arrays are equal */
+    var arraysEqual = function(a, b) {
+      if (a === b) return true;
+      if (a == null || b == null) return false;
+      if (a.length != b.length) return false;
+
+      // If you don't care about the order of the elements inside
+      // the array, you should sort both arrays here.
+      var aCopy = a.concat().sort();
+      var bCopy = b.concat().sort();
+
+
+      for (var i = 0; i < aCopy.length; ++i) {
+        if (aCopy[i] !== bCopy[i]) return false;
+      }
+      return true;
+    }
+
+
     /**
      * Convert dynamic collection objects to arrays
      */
@@ -166,6 +185,10 @@ function plugin(opts){
       keys.forEach(function(key){
         if (!Array.isArray(metadata[key]) && 'string' !== typeof metadata[key]) {
           var names = Object.keys(metadata[key]).sort();
+          var dynamicOrder = opts[key].orderDynamicCollections;
+          if(dynamicOrder && arraysEqual(names, dynamicOrder)) {
+            names = dynamicOrder;
+          }
 
           convert(names, metadata[key]);
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "debug": "~0.7.4",
     "extend": "~1.2.1",
-    "minimatch": "^0.2.14",
+    "minimatch": "^3.0.3",
     "uniq": "0.0.2",
     "read-metadata": "0.0.2"
   },


### PR DESCRIPTION
Added a new option, `orderDynamicCollections`, to use for sorting the results that come back from dynamic collections.
